### PR TITLE
Fix deprecated huggingface download

### DIFF
--- a/CRAFT/basenet/vgg16_bn.py
+++ b/CRAFT/basenet/vgg16_bn.py
@@ -27,10 +27,10 @@ def init_weights(modules):
 
 
 class vgg16_bn(torch.nn.Module):
-    def __init__(self, pretrained=True, freeze=True):
+    def __init__(self, weights=True, freeze=True):
         super(vgg16_bn, self).__init__()
         model_urls['vgg16_bn'] = model_urls['vgg16_bn'].replace('https://', 'http://')
-        vgg_pretrained_features = models.vgg16_bn(pretrained=pretrained).features
+        vgg_pretrained_features = models.vgg16_bn(weights=weights).features
         self.slice1 = torch.nn.Sequential()
         self.slice2 = torch.nn.Sequential()
         self.slice3 = torch.nn.Sequential()
@@ -52,7 +52,7 @@ class vgg16_bn(torch.nn.Module):
                 nn.Conv2d(1024, 1024, kernel_size=1)
         )
 
-        if not pretrained:
+        if not weights:
             init_weights(self.slice1.modules())
             init_weights(self.slice2.modules())
             init_weights(self.slice3.modules())

--- a/CRAFT/craft.py
+++ b/CRAFT/craft.py
@@ -33,11 +33,11 @@ class double_conv(nn.Module):
 
 class CRAFT(nn.Module):
     
-    def __init__(self, pretrained=False, freeze=False):
+    def __init__(self, weights=False, freeze=False):
         super(CRAFT, self).__init__()
 
         """ Base network """
-        self.basenet = vgg16_bn(pretrained, freeze)
+        self.basenet = vgg16_bn(weights, freeze)
 
         """ U network """
         self.upconv1 = double_conv(1024, 512, 256)

--- a/CRAFT/model.py
+++ b/CRAFT/model.py
@@ -71,7 +71,6 @@ class CRAFTModel:
         for model_name in ['craft', 'refiner']:
             config = HF_MODELS[model_name]
             paths[model_name] = os.path.join(cache_dir, config['filename'])
-           
             if not local_files_only:
                 paths[model_name] = hf_hub_download(
                     repo_id=config['repo_id'],

--- a/CRAFT/model.py
+++ b/CRAFT/model.py
@@ -217,3 +217,4 @@ class CRAFTModel:
         
         boxes_final = self._get_boxes_preproc(x, ratio_w, ratio_h)
         return boxes_final
+

--- a/CRAFT/model.py
+++ b/CRAFT/model.py
@@ -147,37 +147,6 @@ class CRAFTModel:
             batch_polys = pool.map(process_single, batch_args)
 
         return batch_polys
-
-        # TODO can we do some of this stuff in parallel
-        # batch_polys = []
-
-        # for b_idx in range(batch_size):
-            
-        #     # Get current ratios
-        #     curr_ratio_w = ratios_w[b_idx].item() if isinstance(ratios_w, torch.Tensor) else ratios_w
-        #     curr_ratio_h = ratios_h[b_idx].item() if isinstance(ratios_h, torch.Tensor) else ratios_h
-            
-        #     # Use existing OpenCV-based post-processing
-        #     boxes, polys = getDetBoxes(
-        #         text_scores[b_idx], link_scores[b_idx],
-        #         self.text_threshold, self.link_threshold,
-        #         self.low_text, False  # Don't need detailed polygons, just boxes
-        #     )
-            
-        #     # Adjust coordinates
-        #     boxes = adjustResultCoordinates(boxes, curr_ratio_w, curr_ratio_h)
-            
-        #     # Convert to tensor and add to batch
-        #     image_polys = []
-        #     if len(boxes) > 0:
-        #         # Ensure boxes is in a list format before processing
-        #         boxes = boxes.tolist() if isinstance(boxes, np.ndarray) else boxes
-        #         for box in boxes:
-        #             image_polys.append(box)
-                    
-        #     batch_polys.append(image_polys)
-
-        # return batch_polys
     
     def _convex_hull(self, x_coords, y_coords):
         """Simple convex hull approximation for GPU tensors"""

--- a/CRAFT/model.py
+++ b/CRAFT/model.py
@@ -6,7 +6,7 @@ from torch.autograd import Variable
 from PIL import Image
 import numpy as np
 import cv2
-from huggingface_hub import hf_hub_url, cached_download
+from huggingface_hub import hf_hub_url, hf_hub_download
 
 from CRAFT.craft import CRAFT, init_CRAFT_model
 from CRAFT.refinenet import RefineNet, init_refiner_model
@@ -71,9 +71,13 @@ class CRAFTModel:
         for model_name in ['craft', 'refiner']:
             config = HF_MODELS[model_name]
             paths[model_name] = os.path.join(cache_dir, config['filename'])
+            # Replacement code
             if not local_files_only:
-                config_file_url = hf_hub_url(repo_id=config['repo_id'], filename=config['filename'])
-                cached_download(config_file_url, cache_dir=cache_dir, force_filename=config['filename'])
+                paths[model_name] = hf_hub_download(
+                    repo_id=config['repo_id'],
+                    filename=config['filename'],
+                    cache_dir=cache_dir
+                )
             
         self.net = init_CRAFT_model(paths['craft'], device, fp16=fp16)
         if self.use_refiner:

--- a/CRAFT/model.py
+++ b/CRAFT/model.py
@@ -71,7 +71,7 @@ class CRAFTModel:
         for model_name in ['craft', 'refiner']:
             config = HF_MODELS[model_name]
             paths[model_name] = os.path.join(cache_dir, config['filename'])
-            # Replacement code
+           
             if not local_files_only:
                 paths[model_name] = hf_hub_download(
                     repo_id=config['repo_id'],

--- a/CRAFT/model.py
+++ b/CRAFT/model.py
@@ -123,8 +123,8 @@ class CRAFTModel:
         batch_size = batch_images.size(0)
         # Process each image in the batch (minimize CPU transfers)
         batch_polys = []
-        text_scores = text_scores.cpu().numpy()
-        link_scores = link_scores.cpu().numpy()
+        text_scores = text_scores.detach().cpu().numpy()
+        link_scores = link_scores.detach().cpu().numpy()
         # ratios_w = ratios_w.cpu().numpy()
         # ratios_h = ratios_h.cpu().numpy()
 

--- a/CRAFT/model.py
+++ b/CRAFT/model.py
@@ -106,7 +106,7 @@ class CRAFTModel:
     def get_batch_polygons(self, batch_images: torch.Tensor, ratios_w: torch.Tensor, ratios_h: torch.Tensor):
         """Batch process pre-normalized images on GPU"""
         # Forward pass
-        batch_images = batch_images.float()  # Convert to float32
+        #batch_images = batch_images.float()  # Convert to float32
         if self.fp16:
             batch_images = batch_images.half()  # Convert to half if using fp16
 

--- a/CRAFT/model.py
+++ b/CRAFT/model.py
@@ -107,13 +107,15 @@ class CRAFTModel:
         """Batch process pre-normalized images on GPU"""
         # Forward pass
         with torch.no_grad():
-            y, _ = self.net(batch_images)
+            y, feature = self.net(batch_images.to(self.device)) 
             if self.refiner:
-                y, _ = self.refiner(y, None)
+                y_refiner = self.refiner(y, feature)
+                link_scores = y_refiner[..., 0]  # [B, H, W]
+            else:
+                link_scores = y[..., 1]  # [B, H, W]
+            
+            text_scores = y[..., 0]  # [B, H, W]
 
-        # Batch post-processing
-        text_scores = y[..., 0]  # [B, H, W]
-        link_scores = y[..., 1] if not self.refiner else y[..., 0]
         
         # Threshold maps on GPU
         text_mask = (text_scores > self.text_threshold)
@@ -148,53 +150,24 @@ class CRAFTModel:
             batch_polys.append(polys)
 
         return batch_polys
+    
+    def _convex_hull(self, x_coords, y_coords):
+        """Simple convex hull approximation for GPU tensors"""
+        # For character detection, a simple bounding box is often sufficient
+        min_x = torch.min(x_coords)
+        max_x = torch.max(x_coords)
+        min_y = torch.min(y_coords)
+        max_y = torch.max(y_coords)
 
+        # Create rectangle corners
+        pts = torch.tensor([
+            [min_x, min_y],
+            [max_x, min_y],
+            [max_x, max_y],
+            [min_x, max_y]
+        ], device=x_coords.device)
 
-    def get_batch_polygons(self, batch_images: torch.Tensor, ratios_w: torch.Tensor, ratios_h: torch.Tensor):
-        """Batch process pre-normalized images on GPU"""
-        # Forward pass
-        with torch.no_grad():
-            y, _ = self.net(batch_images)
-            if self.refiner:
-                y, _ = self.refiner(y, None)
-
-        # Batch post-processing
-        text_scores = y[..., 0]  # [B, H, W]
-        link_scores = y[..., 1] if not self.refiner else y[..., 0]
-        
-        # Threshold maps on GPU
-        text_mask = (text_scores > self.text_threshold)
-        link_mask = (link_scores > self.link_threshold)
-        combined_mask = text_mask & link_mask
-
-        # Find connected components using PyTorch's label
-        batch_labels = [
-            torch.ops.torchvision.label_connected_components(mask.float())
-            for mask in combined_mask
-        ]
-
-        # Extract polygon coordinates for each component
-        batch_polys = []
-        for b_idx in range(batch_images.size(0)):
-            polys = []
-            for label in torch.unique(batch_labels[b_idx]):
-                if label == 0: continue
-                # Get component coordinates (GPU tensor)
-                y_coords, x_coords = torch.where(batch_labels[b_idx] == label)
-                if len(x_coords) < 4: continue
-                
-                # Find convex hull (custom kernel or approximation)
-                poly_points = self._convex_hull(x_coords, y_coords)
-                
-                # Scale coordinates using precomputed ratios
-                scaled_poly = poly_points * torch.tensor([
-                    [ratios_w[b_idx], ratios_h[b_idx]]
-                ], device=self.device)
-                
-                polys.append(scaled_poly)
-            batch_polys.append(polys)
-
-        return batch_polys
+        return pts
 
     def get_polygons(self, image: Image.Image) -> List[List[List[int]]]:
         x, ratio_w, ratio_h = preprocess_image(np.array(image), self.canvas_size, self.mag_ratio)

--- a/CRAFT/model.py
+++ b/CRAFT/model.py
@@ -125,8 +125,8 @@ class CRAFTModel:
         batch_polys = []
         text_scores = text_scores.cpu().numpy()
         link_scores = link_scores.cpu().numpy()
-        ratios_w = ratios_w.cpu().numpy()
-        ratios_h = ratios_h.cpu().numpy()
+        # ratios_w = ratios_w.cpu().numpy()
+        # ratios_h = ratios_h.cpu().numpy()
 
         # TODO can we do some of this stuff in parallel
         for b_idx in range(batch_size):
@@ -146,7 +146,6 @@ class CRAFTModel:
             )
             
             # Adjust coordinates
-            breakpoint()
             boxes = adjustResultCoordinates(boxes, curr_ratio_w, curr_ratio_h)
             
             # Convert to tensor and add to batch

--- a/CRAFT/model.py
+++ b/CRAFT/model.py
@@ -103,6 +103,99 @@ class CRAFTModel:
             
         return score_text, score_link
 
+    def get_batch_polygons(self, batch_images: torch.Tensor, ratios_w: torch.Tensor, ratios_h: torch.Tensor):
+        """Batch process pre-normalized images on GPU"""
+        # Forward pass
+        with torch.no_grad():
+            y, _ = self.net(batch_images)
+            if self.refiner:
+                y, _ = self.refiner(y, None)
+
+        # Batch post-processing
+        text_scores = y[..., 0]  # [B, H, W]
+        link_scores = y[..., 1] if not self.refiner else y[..., 0]
+        
+        # Threshold maps on GPU
+        text_mask = (text_scores > self.text_threshold)
+        link_mask = (link_scores > self.link_threshold)
+        combined_mask = text_mask & link_mask
+
+        # Find connected components using PyTorch's label
+        batch_labels = [
+            torch.ops.torchvision.label_connected_components(mask.float())
+            for mask in combined_mask
+        ]
+
+        # Extract polygon coordinates for each component
+        batch_polys = []
+        for b_idx in range(batch_images.size(0)):
+            polys = []
+            for label in torch.unique(batch_labels[b_idx]):
+                if label == 0: continue
+                # Get component coordinates (GPU tensor)
+                y_coords, x_coords = torch.where(batch_labels[b_idx] == label)
+                if len(x_coords) < 4: continue
+                
+                # Find convex hull (custom kernel or approximation)
+                poly_points = self._convex_hull(x_coords, y_coords)
+                
+                # Scale coordinates using precomputed ratios
+                scaled_poly = poly_points * torch.tensor([
+                    [ratios_w[b_idx], ratios_h[b_idx]]
+                ], device=self.device)
+                
+                polys.append(scaled_poly)
+            batch_polys.append(polys)
+
+        return batch_polys
+
+
+    def get_batch_polygons(self, batch_images: torch.Tensor, ratios_w: torch.Tensor, ratios_h: torch.Tensor):
+        """Batch process pre-normalized images on GPU"""
+        # Forward pass
+        with torch.no_grad():
+            y, _ = self.net(batch_images)
+            if self.refiner:
+                y, _ = self.refiner(y, None)
+
+        # Batch post-processing
+        text_scores = y[..., 0]  # [B, H, W]
+        link_scores = y[..., 1] if not self.refiner else y[..., 0]
+        
+        # Threshold maps on GPU
+        text_mask = (text_scores > self.text_threshold)
+        link_mask = (link_scores > self.link_threshold)
+        combined_mask = text_mask & link_mask
+
+        # Find connected components using PyTorch's label
+        batch_labels = [
+            torch.ops.torchvision.label_connected_components(mask.float())
+            for mask in combined_mask
+        ]
+
+        # Extract polygon coordinates for each component
+        batch_polys = []
+        for b_idx in range(batch_images.size(0)):
+            polys = []
+            for label in torch.unique(batch_labels[b_idx]):
+                if label == 0: continue
+                # Get component coordinates (GPU tensor)
+                y_coords, x_coords = torch.where(batch_labels[b_idx] == label)
+                if len(x_coords) < 4: continue
+                
+                # Find convex hull (custom kernel or approximation)
+                poly_points = self._convex_hull(x_coords, y_coords)
+                
+                # Scale coordinates using precomputed ratios
+                scaled_poly = poly_points * torch.tensor([
+                    [ratios_w[b_idx], ratios_h[b_idx]]
+                ], device=self.device)
+                
+                polys.append(scaled_poly)
+            batch_polys.append(polys)
+
+        return batch_polys
+
     def get_polygons(self, image: Image.Image) -> List[List[List[int]]]:
         x, ratio_w, ratio_h = preprocess_image(np.array(image), self.canvas_size, self.mag_ratio)
         


### PR DESCRIPTION
In case it helps anyone else, I fixed an error downloading the model from Hugginface! In your `example.ipynb` there is a warning about the same. 
```
/home/user/conda/lib/python3.7/site-packages/huggingface_hub/file_download.py:654: FutureWarning: 'cached_download' is the legacy way to download files from the HF hub, please consider upgrading to 'hf_hub_download'
  FutureWarning,
 ```

The change replaces the two-step process (generate URL, then download) with the direct hf_hub_download function which takes the repo_id and filename parameters. It also updates the paths[model_name] value to use the actual path returned by hf_hub_download, which I suspect will be more robust if the HF cache structure changes. 

By the way, cool repo and thank you for sharing it!